### PR TITLE
[WIP] Fix private parameters and Struct types

### DIFF
--- a/src/ros_model_parser/rossystem_parser.py
+++ b/src/ros_model_parser/rossystem_parser.py
@@ -54,7 +54,7 @@ class RosSystemModelParser(object):
         name = Optional(SQ) + Optional(DQ) + Word(printables,
                                    excludeChars="{},'") + Optional(SQ) + Optional(DQ)
 
-        real = Combine(Word(nums) + '.' + Word(nums))
+        real = pyparsing_common.number.copy()
 
         listStr = Forward()
         mapStr = Forward()

--- a/src/ros_model_parser/rossystem_parser.py
+++ b/src/ros_model_parser/rossystem_parser.py
@@ -181,13 +181,13 @@ class RosSystemModelParser(object):
             _interface +
             OCB +
             _name + name("interface_name") +
-            Optional(parameters)("parameters") +
             Optional(publishers)("publishers") +
             Optional(subscribers)("subscribers") +
             Optional(services)("services") +
             Optional(srv_clients)("srv_clients") +
             Optional(action_servers)("action_servers") +
             Optional(action_clients)("action_clients") +
+            Optional(parameters)("parameters") +
             CCB)
 
         self.rossystem_grammar = _system + \


### PR DESCRIPTION
Handles:
```
Parameter { name '/imu/data/rate/gaussian_noise' type Double  value 5e-05},
Parameter { name '/safety_distance_publisher_node/scan_filter_chain' type Struct {
            'type' String,
            'params' Struct{
              'lower_angle' Double,
              'upper_angle' Double},
            'name' String} value {
                { 'type' { value 'laser_filters/LaserScanAngularBoundsFilter'}},
                { 'params' { value {
                    { 'lower_angle' { value -1.57}},
                    { 'upper_angle' { value 1.57}}},
                { 'name' { value 'angle'}}}}}},
          Parameter { name '/move_base/global_costmap/obstacles_layer/point_cloud/obstacle_range' type Double  value 8.0},
          Parameter { name '/move_base/local_costmap/plugins' type Struct {
            'type' String,
            'name' String} value {
                { 'type' { value 'costmap_2d::StaticLayer'}},
                { 'name' { value 'static_layer'}}}},
Parameter { name '/rosgraph_manipulator/configs' type List {String,String,String,String,String,String,String,String,String,String,String,String,String,String,String,String,String,String,String,String,String,String,String,String,String,String,String,String,String,String} value {'f1_v1_r1', 'f1_v1_r2', 'f1_v1_r3', 'f1_v2_r1', 'f1_v2_r2', 'f1_v2_r3', 'f1_v3_r1', 'f1_v3_r2', 'f1_v3_r3', 'f2_v1_r1', 'f2_v1_r2', 'f2_v1_r3', 'f2_v2_r1', 'f2_v2_r2', 'f2_v2_r3', 'f2_v3_r1', 'f2_v3_r2', 'f2_v3_r3', 'f3_v1_r1', 'f3_v1_r2', 'f3_v1_r3', 'f3_v2_r1', 'f3_v2_r2', 'f3_v2_r3', 'f3_v3_r1', 'f3_v3_r2', 'f3_v3_r3', 'f1_v1_r3_k', 'f1_v3_r1_k', 'f2_v1_r3_k'}}
```