### PR TITLE
Install the templates folder under lib, to be found while calling the geneartor from python directly, i.e., out of a ROS node

### DIFF
--- a/ros2model/api/model_generator/component_generator.py
+++ b/ros2model/api/model_generator/component_generator.py
@@ -18,8 +18,12 @@ from pathlib import Path
 
 from ros2model.core.generator.generator_core import GeneratorCore
 import typing as t
+import pkg_resources
+import os
 
-Template_Folder = Path(__file__).parent.parent.parent.parent.resolve() / "templates"
+#Template_Folder = Path(__file__).parent.parent.parent.parent.resolve() / "templates"
+Package_path=os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(pkg_resources.resource_filename('ros2model', '')))))
+Template_Folder = Path(os.path.join(os.path.join(os.path.join(Package_path,'share'),'ros2model'),'templates'))
 Template = Path(Template_Folder / "component.ros2.j2")
 
 

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,10 @@ setup(
             ["templates/component.ros2.j2", "templates/rossystem.rossystem.j2"],
         ),
     ],
+    package_data={
+        package_name: ['templates/*.j2'],
+    },
+    include_package_data=True,
     install_requires=[
         "jinja2",
         "pydantic",


### PR DESCRIPTION
For the ros-model-extractors I call the code generator out of ROS, directly from python. Unfortunately, doing so I was not able to init the generator as the template files coulnd't be found. To try it sou can directly call the following commands:

```
$ python3
$ >>> from ros2model.api.model_generator.component_generator import ComponentGenerator
$ >>> node_generator = ComponentGenerator()
```

This will give back:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/tmp/ros2ws/install/ros2model/lib/python3.10/site-packages/ros2model/api/model_generator/component_generator.py", line 52, in __init__
    super().__init__(self.template_path, ".ros2")
  File "/tmp/ros2ws/install/ros2model/lib/python3.10/site-packages/ros2model/core/generator/generator_core.py", line 42, in __init__
    raise GeneratorError(f"{self.template_path} doesn't exist")
ros2model.core.exceptions.GeneratorError: /tmp/ros2ws/install/ros2model/lib/python3.10/site-packages/templates/component.ros2.j2 doesn't exist
```

I am not sure if the changes I am proposing are the right ones or if a new ifelse block should be added.
